### PR TITLE
Only utilize public methods when interacting with URI

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,28 +1,36 @@
 Revision history for Catalyst::Plugin::VersionedURI
 
 {{$NEXT}}
-  - Now use 'Catalyst::DispatchType::Regex'
-    explicitly to placate the deprecation notice.
+  [ API CHANGES ]
+
+  [ BUG FIXES ]
+
+  [ DOCUMENTATION ]
+
+  [ ENHANCEMENTS ]
+
+  [ NEW FEATURES ]
+
+  [ STATISTICS ]
+
+1.1.2 2015-11-29
+  - Now use 'Catalyst::DispatchType::Regex' explicitly to placate the
+    deprecation notice.
   - Use Path::Tiny instead of Path::Class.
 
- [API CHANGES]
-
- [BUG FIXES]
-
- [ENHANCEMENTS]
-
+  [ STATISTICS ]
+    - code churn: 4 files changed, 35 insertions(+), 13 deletions(-)
 
 1.1.1 2011-08-29
- - 'uri' now defaults to '/static'
+  - 'uri' now defaults to '/static'
 
 1.1.0 2011-02-07
- - the version token can now be generated from the mtime of the file.
-   (thanks to mvgrimes for the patch)
+  - the version token can now be generated from the mtime of the file.
+    (thanks to mvgrimes for the patch)
 
 1.0.0 2011-01-03
- - By default, add the versioned element to the query instead than the
-   path. (thanks to Alexander Hartmaier for pointing that out)
+  - By default, add the versioned element to the query instead than the
+    path. (thanks to Alexander Hartmaier for pointing that out)
 
 0.1.0 2011-01-02
- - Initial release.
-
+  - Initial release.

--- a/lib/Catalyst/Plugin/VersionedURI.pm
+++ b/lib/Catalyst/Plugin/VersionedURI.pm
@@ -199,15 +199,14 @@ around uri_for => sub {
     my $uris_re = $self->versioned_uri_regex
         or return $uri;
 
-    my $base = $self->req->base;
-    $base =~ s#(?<!/)$#/#;  # add trailing '/'
-
-    return $uri unless $$uri =~  m#(^\Q$base\E$uris_re)#;
+    return $uri unless $uri->path =~ m#^/($uris_re)#;
 
     my $version = $self->uri_version( $uri, @args );
 
     if ( state $in_path = $self->config->{'Plugin::VersionedURI'}{in_path} ) {
-        $$uri =~ s#(^\Q$base\E$uris_re)#${1}v$version/#;
+        my $path = $uri->path;
+        $path =~ s#^/($uris_re)#${1}v$version/#;
+        $uri->path( $path );
     } 
     else {
         state $version_name = $self->config->{'Plugin::VersionedURI'}{param} || 'v';


### PR DESCRIPTION
This changes the around 'uri_for' code to only interact with the URI
(which is returned by the original method) through public methods. This
allows the user to use other plugins that interact with URI (ie,
Catalyst::Plugin::SmartURI).
